### PR TITLE
fix: remove PyPi installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,49 +11,6 @@ This project was made specifically for the "Linux Gamers". Other operating syste
 
 To install ScafL, you first need Python 3.6+ installed and pip. Check your Linux distribution on how to install both of these dependencies.
 
-### Installing on your system
-
-To install ScafL on your system, you need to ensure that [GTK and PyGObject is installed on your system](https://pygobject.readthedocs.io/en/latest/getting_started.html).
-Then run the following command on your terminal:
-
-```sh
-$ pip install scafl
-$ python -m scafl
-```
-
-### Installing inside a virtual environment
-
-If you want to install the project in a virtual environment, to avoid any dependency conflict, first ensure venv is installed. Then, run the following:
-
-```sh
-$ python -m venv /path/to/your/virtual/environment
-$ source /path/to/your/virtual/environment/bin/activate
-```
-
-Now, while still in your virtual environment, install the package by running the following command:
-
-```sh
-(env) $ pip install pycairo pygobject scafl
-```
-
-You now have ScafL installed on your virtual environment. This means that every time you want to run ScafL, you need to have the virtual environment activated, which is done by running:
-
-```sh
-$ source /path/to/your/virtual/environment/bin/activate
-```
-
-To run ScafL, run this command on your terminal:
-
-```sh
-(env) $ python -m scafl
-```
-
-To exit the virtual environment, run:
-
-```sh
-(env) $ deactivate
-```
-
 ### Running from source
 
 To run ScafL from source, it is recommended that you run it on a virtual environment. To create a virtual environment, run the following command inside the project directory:


### PR DESCRIPTION
Remove PyPi instructions. ScafL won't be distributed via PyPi anymore.